### PR TITLE
Better release changelogs

### DIFF
--- a/.github/changelog_configuration.json
+++ b/.github/changelog_configuration.json
@@ -1,0 +1,20 @@
+{
+    "categories": [
+        {
+            "title": "## 🚀 Enhancements",
+            "labels": ["enhancement"]
+        },
+        {
+            "title": "## 🐛 Fixes",
+            "labels": ["bug"]
+        },
+        {
+            "title": "## 📖 Documentation",
+            "labels": ["documentation"]
+        },
+        {
+            "title": "## 💬 Other",
+            "labels": ["other"]
+        }
+    ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,13 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Build Changelog
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v1
+        with:
+          configuration: ".github/changelog_configuration.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Let's adjust the changelog configuration a bit such that PRs are grouped by default labels provided by GitHub. Since this requires a separate JSON file, we need to perform a checkout as part of the release.