### PR TITLE
Simplify Gigalixir deployment

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,0 +1,4 @@
+config :rummy, RummyWeb.Endpoint,
+  server: true,
+  http: [port: {:system, "PORT"}],
+  url: [host: System.get_env("APP_NAME") <> ".gigalixirapp.com", port: 443]

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,3 +1,0 @@
-elixir_version=1.12.2
-erlang_version=23.3.2
-hook_post_compile="mix assets.deploy && rm -f _build/esbuild"

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,1 +1,0 @@
-node_version=14.17.4


### PR DESCRIPTION
My reading of https://gigalixir.readthedocs.io/en/latest/modify-app/releases.html# is that a config/releases.exs file can be used to signal that Gigalixir ought to do an Elixir release. In that case, we don't seem to need buildpack files, which I never liked. Let's give it a try.