### PR TITLE
Actually fix Gigalixir deployment

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "deploy": "cd .. && mix assets.deploy && rm -f _build/esbuild"
+  }
+}

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,3 +1,5 @@
+import Config
+
 config :rummy, RummyWeb.Endpoint,
   server: true,
   http: [port: {:system, "PORT"}],

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,2 @@
+elixir_version=1.12.2
+erlang_version=23.3.2


### PR DESCRIPTION
It appears that the elixir_buildpack.config file is needed after all.
However, the Gigalixir deployment instructions seem to have changed.

The mix assets.deploy call should go into the package.json file.

Also, add a missing import in config/releases.exs -- without this,
'config' is unknown.